### PR TITLE
Add patches from Quectel USB Driver User Guide

### DIFF
--- a/drivers/usb/serial/option.c
+++ b/drivers/usb/serial/option.c
@@ -2125,6 +2125,9 @@ static struct usb_serial_driver option_1port_device = {
 #ifdef CONFIG_PM
 	.suspend           = usb_wwan_suspend,
 	.resume            = usb_wwan_resume,
+#if 1 //Added by Quectel
+	.reset_resume      = usb_wwan_resume,
+#endif
 #endif
 };
 

--- a/drivers/usb/serial/option.c
+++ b/drivers/usb/serial/option.c
@@ -2171,6 +2171,20 @@ static int option_probe(struct usb_serial *serial,
 	if (device_flags & NUMEP2 && iface_desc->bNumEndpoints != 2)
 		return -ENODEV;
 
+#if 1 //Added by Quectel
+	//Quectel modules’s interface 4 can be used as USB network device
+	if (serial->dev->descriptor.idVendor == cpu_to_le16(0x2C7C)) {
+	//some interfaces can be used as USB Network device (ecm, rndis, mbim)
+		if (serial->interface->cur_altsetting->desc.bInterfaceClass != 0xFF) {
+			return -ENODEV;
+		}
+		//interface 4 can be used as USB Network device (qmi)
+		else if (serial->interface->cur_altsetting->desc.bInterfaceNumber >= 4) {
+			return -ENODEV;
+		}
+	}
+#endif
+
 	/* Store the device flags so we can use them during attach. */
 	usb_set_serial_data(serial, (void *)device_flags);
 

--- a/drivers/usb/serial/option.c
+++ b/drivers/usb/serial/option.c
@@ -2183,6 +2183,13 @@ static int option_probe(struct usb_serial *serial,
 			return -ENODEV;
 		}
 	}
+
+	// USB autosuspend
+	if (serial->dev->descriptor.idVendor == cpu_to_le16(0x2C7C)) {
+		pm_runtime_set_autosuspend_delay(&serial->dev->dev, 3000);
+		usb_enable_autosuspend(serial->dev);
+		device_init_wakeup(&serial->dev->dev, 1); //usb remote wakeup
+	}
 #endif
 
 	/* Store the device flags so we can use them during attach. */

--- a/drivers/usb/serial/usb_wwan.c
+++ b/drivers/usb/serial/usb_wwan.c
@@ -480,6 +480,14 @@ static struct urb *usb_wwan_setup_urb(struct usb_serial_port *port,
 	if (intfdata->use_zlp && dir == USB_DIR_OUT)
 		urb->transfer_flags |= URB_ZERO_PACKET;
 
+#if 1 //Added by Quectel for zero packet
+	if (dir == USB_DIR_OUT) {
+		struct usb_device_descriptor *desc = &serial->dev->descriptor;
+		if (desc->idVendor == cpu_to_le16(0x2C7C))
+			urb->transfer_flags |= URB_ZERO_PACKET;
+	}
+#endif
+
 	return urb;
 }
 


### PR DESCRIPTION
Quectel suggests certain driver changes in their user guide. Add the ones we've already used plus one new, enabling modem USB autosuspend.